### PR TITLE
Remove committer name from git log format string. (#7)

### DIFF
--- a/store/reader.go
+++ b/store/reader.go
@@ -28,7 +28,7 @@ func ParseInputType(input string) InputType {
 }
 
 func CommitMeasureCommand(prefix string) *exec.Cmd {
-	return GitLog("git-ratchet-1-"+prefix, "HEAD", `%H,%an <%ae>,%at,"%N",`)
+	return GitLog("git-ratchet-1-"+prefix, "HEAD", `%H,%ae,%at,"%N",`)
 }
 
 func CommitMeasures(gitlog *exec.Cmd) (func() (CommitMeasure, error), error) {


### PR DESCRIPTION
This does not prevent quotes from messing up the output. However, it does remove the most likely candidate for containing quotes.
