### PR TITLE
Fix adding notes to use absolute path

### DIFF
--- a/store/git.go
+++ b/store/git.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+	"path/filepath"
 )
 
 func GitLog(ref string, commitrange string, format string) *exec.Cmd {
@@ -48,7 +49,7 @@ func WriteNotes(writef func(io.Writer) error, ref string) error {
 		return fmt.Errorf("Error closing .git-ratchet-note %s", err)
 	}
 
-	writenotes := exec.Command("git", "notes", "--ref="+ref, "add", "-f", "-F", notepath)
+	writenotes := exec.Command("git", "notes", "--ref="+ref, "add", "-f", "-F", filepath.Abs(notepath))
 
 	log.INFO.Println(strings.Join(writenotes.Args, " "))
 


### PR DESCRIPTION
Relative path is ambiguously relative to current directory or git root

When running `git notes add -F` it seems like the file is relative to git root rather than current directory. Maybe this is an issue with git, but we can be a bit more robust by using an absolute path
