### PR TITLE
Changing double quotes to single quotes as git log is double quoting …

### DIFF
--- a/store/reader.go
+++ b/store/reader.go
@@ -28,7 +28,7 @@ func ParseInputType(input string) InputType {
 }
 
 func CommitMeasureCommand(prefix string) *exec.Cmd {
-	return GitLog("git-ratchet-1-"+prefix, "HEAD", `%H,%ae,%at,"%N",`)
+	return GitLog("git-ratchet-1-"+prefix, "HEAD", `%H,%ae,%at,'%N',`)
 }
 
 func CommitMeasures(gitlog *exec.Cmd) (func() (CommitMeasure, error), error) {


### PR DESCRIPTION
…%N lines with spaces in them leading to fields having mismatched quotes. This should fix that